### PR TITLE
feature(510297): Added support for selecting ingress controller (NGINX / Traefik) via variable on AWS-EKS

### DIFF
--- a/aws-eks/README.md
+++ b/aws-eks/README.md
@@ -34,9 +34,10 @@ Bold BI Terraform EKS deployments have been tested and validated with the follow
 
 ### BoldBI Kubernetes Compatibility
 
-| **BoldBI Version** | **Kubernetes Supported Versions** | **ingress-nginx Tested Versions** | **Tested Environments** | **Release Date** |
-|--------------------|-----------------------------------|-----------------------------------|------------------------|------------------|
-| Latest (13.1.10)    | 1.32.x, 1.31.x, 1.30.x            | 4.0.10                  | EKS 1.32     | 2025-07-15       |
+| **BoldBI Version** | **Kubernetes Supported Versions** | **ingress-nginx Tested Versions** | **ingress-traefik Tested Versions** | **Tested Environments** | **Release Date** |
+|--------------------|-----------------------------------|-----------------------------------|-----------------------------------|------------------------|------------------|
+| (13.1.10)    | 1.32.x, 1.31.x, 1.30.x            | 4.0.10                  | -                     | EKS 1.32     | 2025-07-15       |
+| Latest (15.3.8)    | 1.32.x, 1.31.x, 1.30.x            | 4.0.10                  | 3.6.10                | EKS 1.32     | 2026-04-27       |
 
 ---
 
@@ -114,6 +115,24 @@ Application Variables after setting in AWS Secrets Manager:
 - If you need to change any infrastructure or application-level settings, refer to the `terraform.tfvars` file.
 
 - If you do not set the secrets in either location, Terraform will prompt you for the values during execution.
+
+### Ingress Controller (Load Balancer) Support
+
+This Terraform setup supports dynamic selection of the ingress controller using a variable.
+
+#### Supported Options
+
+- **nginx** (default)
+- **traefik**
+
+#### Configuration
+
+You can choose the ingress controller by setting the following variable in `terraform.tfvars`:
+
+```sh
+load_balancer_type = "nginx"   # "nginx" or "traefik"
+```
+
 
 ### Step 4: Initialize Terraform
 

--- a/aws-eks/main.tf
+++ b/aws-eks/main.tf
@@ -346,6 +346,8 @@ resource "aws_iam_role_policy_attachment" "ecr_read_only" {
 
 # Install NGINX Ingress Controller using Helm
 resource "helm_release" "nginx_ingress" {
+  count      = var.load_balancer_type == "nginx" ? 1 : 0
+
   name       = "nginx-ingress"
   namespace  = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
@@ -362,30 +364,63 @@ resource "helm_release" "nginx_ingress" {
     {
       name  = "controller.service.externalTrafficPolicy"
       value = "Local"
-    }]
+    }
+  ]
 
   depends_on = [aws_eks_cluster.eks_cluster, aws_eks_node_group.eks_nodes]
 }
 
-# Fetch the status of the Kubernetes service created by the Helm release
-resource "time_sleep" "wait_for_nginx_service" {
-  depends_on = [helm_release.nginx_ingress]
+# Install Traefik Ingress Controller using Helm
+resource "helm_release" "traefik_ingress" {
+  count      = var.load_balancer_type == "traefik" ? 1 : 0
 
-  create_duration = "30s"
+  name       = "traefik"
+  namespace  = "traefik"
+  repository = "https://traefik.github.io/charts"
+  chart      = "traefik"
+
+  create_namespace = true
+
+  set = [
+    {
+      name  = "service.type"
+      value = "LoadBalancer"
+    }
+  ]
+
+  depends_on = [aws_eks_cluster.eks_cluster, aws_eks_node_group.eks_nodes]
 }
 
-data "kubernetes_service" "nginx_ingress_service" {
+data "kubernetes_service" "ingress_service" {
+  count = var.load_balancer_type == "nginx" ? 1 : 0
+
   metadata {
     name      = "nginx-ingress-ingress-nginx-controller"
     namespace = "ingress-nginx"
   }
-  depends_on = [time_sleep.wait_for_nginx_service]
+
+  depends_on = [helm_release.nginx_ingress]
 }
 
-resource "time_sleep" "wait_for_nginx_ingress" {
-  create_duration = "300s" # Wait for 5 minutes
-  depends_on      = [data.kubernetes_service.nginx_ingress_service]
+data "kubernetes_service" "traefik_service" {
+  count = var.load_balancer_type == "traefik" ? 1 : 0
+
+  metadata {
+    name      = "traefik"
+    namespace = "traefik"
+  }
+
+  depends_on = [helm_release.traefik_ingress]
 }
+
+locals {
+  ingress_hostname = (
+    var.load_balancer_type == "nginx" ?
+    data.kubernetes_service.ingress_service[0].status[0].load_balancer[0].ingress[0].hostname :
+    data.kubernetes_service.traefik_service[0].status[0].load_balancer[0].ingress[0].hostname
+  )
+}
+
 
 #Create a CNAME record in Route 53 to point to the Nginx Loadbalancer External IP
 resource "aws_route53_record" "alb_cname" {
@@ -395,19 +430,25 @@ resource "aws_route53_record" "alb_cname" {
   name = regex("^([^.]+)", replace(replace(local.app_base_url, "https://", ""), "http://", ""))[0]
   type    = "CNAME"
   ttl     = 60
-  records = [data.kubernetes_service.nginx_ingress_service.status[0].load_balancer[0].ingress[0].hostname]
-  depends_on = [helm_release.nginx_ingress,time_sleep.wait_for_nginx_service]
+  records = [local.ingress_hostname]
+  depends_on = [
+    helm_release.nginx_ingress,
+    helm_release.traefik_ingress
+  ]
 }
 
 resource "cloudflare_record" "alb_cname" {
   count   = local.app_base_url!= "" && local.cloudflare_zone_id != "" && local.route53_zone_id == "" ? 1 : 0
   zone_id = local.cloudflare_zone_id
   name    = regex("^([^.]+)", replace(replace(var.app_base_url, "https://", ""), "http://", ""))[0]
-  value   = data.kubernetes_service.nginx_ingress_service.status[0].load_balancer[0].ingress[0].hostname
+  value   = local.ingress_hostname
   type    = "CNAME" # A record for an IPv4 address
   ttl     = 300  # You can adjust the TTL as needed
   proxied = false  # Set to true if you want Cloudflare's proxy (e.g., CDN, security features)
-  depends_on = [helm_release.nginx_ingress,time_sleep.wait_for_nginx_service]
+  depends_on = [
+    helm_release.nginx_ingress,
+    helm_release.traefik_ingress
+  ]
 }
 
 resource "helm_release" "aws_efs_csi_driver" {
@@ -464,7 +505,7 @@ resource "helm_release" "bold_bi" {
   },
   {
     name  = "appBaseUrl"
-    value = local.app_base_url != "" ? local.app_base_url : "http://${data.kubernetes_service.nginx_ingress_service.status[0].load_balancer[0].ingress[0].hostname}"
+    value = local.app_base_url != "" ? local.app_base_url : "http://${local.ingress_hostname}"
   },
   {
     name  = "image.tag"
@@ -472,7 +513,7 @@ resource "helm_release" "bold_bi" {
   },
   {
     name  = "loadBalancer.type"
-    value = "nginx"
+    value = var.load_balancer_type
   },
   {
     name  = "clusterProvider"
@@ -539,7 +580,7 @@ output "app_base_url" {
 }
 
 output "domain" {
-  value = "http://${data.kubernetes_service.nginx_ingress_service.status[0].load_balancer[0].ingress[0].hostname}"
+  value = "http://${local.ingress_hostname}"
 }
 
 output "resource_name_tag" {

--- a/aws-eks/terraform.tfvars
+++ b/aws-eks/terraform.tfvars
@@ -9,8 +9,11 @@ install_optional_libs = "mongodb,mysql,influxdb,snowflake,oracle,clickhouse,goog
 
 node_instance_type = "t3.xlarge"
 
-bold_bi_version = "13.1.10"
+bold_bi_version = "15.3.8"
 
 instance_class = "db.t3.micro"
 # AWS secret manager ARN
 boldbi_secret_arn = ""
+
+# Update preferred Load Balancer(nginx OR traefik)
+load_balancer_type = "nginx" # nginx OR traefik

--- a/aws-eks/variable.tf
+++ b/aws-eks/variable.tf
@@ -41,6 +41,17 @@ variable "nginx_ingress_version" {
   default = "1.12.0"
 }
 
+variable "load_balancer_type" {
+  description = "Ingress controller type: nginx or traefik"
+  type        = string
+  default     = "nginx"
+
+  validation {
+    condition     = contains(["nginx", "traefik"], var.load_balancer_type)
+    error_message = "Only 'nginx' or 'traefik' are allowed."
+  }
+}
+
 # Bold BI Application Variables
 
 variable "bold_bi_namespace" {


### PR DESCRIPTION
Description

- Added load_balancer_type variable to choose between NGINX and Traefik
- Deploys ingress controller conditionally based on input
- Replaced hardcoded NGINX references with dynamic hostname (local.ingress_hostname)
- Updated Bold BI Helm to use selected load balancer type
- Updated Bold BI to latest release version(v15.3)